### PR TITLE
LLVMCreateMCJITCompilerForModule expects a u64, not size_t

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_uint, c_ulonglong, size_t};
+use libc::{c_int, c_uint, c_ulonglong};
 use ffi::{core, target};
 use ffi::execution_engine as engine;
 use ffi::execution_engine::*;
@@ -151,7 +151,7 @@ impl<'a, 'b:'a> ExecutionEngine<'a, 'b> for JitEngine<'a> {
                 MCJMM: ptr::null_mut()
             };
             let size = mem::size_of::<LLVMMCJITCompilerOptions>();
-            let result = engine::LLVMCreateMCJITCompilerForModule(&mut ee, (&*module).into(), &mut options, size as size_t, &mut out);
+            let result = engine::LLVMCreateMCJITCompilerForModule(&mut ee, (&*module).into(), &mut options, size as u64, &mut out);
             if result == 0 {
                 Ok(ee.into())
             } else {


### PR DESCRIPTION
Now it compiles :-).