### PR TITLE
Remove Modules before Disposing Execution Engine to fix Double Free

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -18,4 +18,5 @@ fn main() {
     ee.with_function(func, |add:extern fn((f64, f64)) -> f64| {
         println!("{} + {} = {}", 1., 2., add((1., 2.)));
     });
+    ee.remove_module(&module);
 }

--- a/examples/demo_3f.rs
+++ b/examples/demo_3f.rs
@@ -26,4 +26,5 @@ fn main() {
             println!("thr {} = {}", i, thr(0 as N))
         }
     });
+    ee.remove_module(&module);
 }

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -38,4 +38,5 @@ fn main() {
             println!("fib {} = {}", i, fib(i))
         }
     });
+    ee.remove_module(&module);
 }

--- a/examples/tan.rs
+++ b/examples/tan.rs
@@ -24,4 +24,5 @@ fn main() {
             println!("tan {} = {}", i, tan(i))
         }
     });
+    ee.remove_module(&module);
 }


### PR DESCRIPTION
This fixes TomBebbington/llvm-rs#25 by removing the compiled module
from the execution engine before the engine is `free`'d.